### PR TITLE
Expand Vector and Quaternion types to accept objects

### DIFF
--- a/.changeset/beige-swans-float.md
+++ b/.changeset/beige-swans-float.md
@@ -1,5 +1,5 @@
 ---
-'@slimevr/common': minor
+'@slimevr/common': patch
 '@slimevr/firmware-protocol': patch
 '@slimevr/firmware-protocol-debugger-utils': patch
 ---

--- a/.changeset/beige-swans-float.md
+++ b/.changeset/beige-swans-float.md
@@ -1,0 +1,7 @@
+---
+'@slimevr/common': minor
+'@slimevr/firmware-protocol': patch
+'@slimevr/firmware-protocol-debugger-utils': patch
+---
+
+Allow Vector and Quaternion types to accept objects

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,5 +1,13 @@
-export type Vector = [number, number, number];
-export type Quaternion = [number, number, number, number];
+export type Vector = [number, number, number] | { x: number; y: number; z: number };
+export type Quaternion = [number, number, number, number] | { x: number; y: number; z: number; w: number };
+
+export function toVector(v: Vector): [number, number, number] {
+  return Array.isArray(v) ? v : [v.x, v.y, v.z];
+}
+
+export function toQuaternion(q: Quaternion): [number, number, number, number] {
+  return Array.isArray(q) ? q : [q.x, q.y, q.z, q.w];
+}
 
 export const formatMACAddressDigit = (mac: number) => {
   return mac.toString(16).padStart(2, '0').toUpperCase();

--- a/packages/firmware-protocol-debugger-utils/src/Sensor.ts
+++ b/packages/firmware-protocol-debugger-utils/src/Sensor.ts
@@ -1,4 +1,4 @@
-import { Quaternion } from '@slimevr/common';
+import { Quaternion, toQuaternion, toVector } from '@slimevr/common';
 import {
   ServerBoundCalibrationFinishedPacket,
   ServerBoundErrorPacket,
@@ -46,7 +46,7 @@ export class Sensor {
         this.log(
           `Received raw calibration data for type ${
             RawCalibrationDataType[rawCalibrationData.dataType]
-          }: ${rawCalibrationData.data.join(', ')}`
+          }: ${toVector(rawCalibrationData.data).join(', ')}`
         );
 
         break;
@@ -165,6 +165,6 @@ export class Sensor {
   }
 
   getRotation() {
-    return this.rotation.latestData;
+    return toQuaternion(this.rotation.latestData);
   }
 }

--- a/packages/firmware-protocol-debugger-utils/src/Tracker.ts
+++ b/packages/firmware-protocol-debugger-utils/src/Tracker.ts
@@ -1,3 +1,4 @@
+import { toVector, toQuaternion } from '@slimevr/common';
 import {
   BoardType,
   DeviceBoundFeatureFlagsPacket,
@@ -177,7 +178,11 @@ export class Tracker {
       case ServerBoundGyroPacket.type: {
         const rot = packet as ServerBoundGyroPacket;
 
-        this.log(`Gyroscope: ${rot.rotation.join(', ')}`);
+        if (Array.isArray(rot.rotation)) {
+          this.log(`Gyroscope: ${rot.rotation.join(', ')}`);
+        } else {
+          this.log(`Gyroscope: ${rot.rotation.x}, ${rot.rotation.y}, ${rot.rotation.z}`);
+        }
 
         break;
       }
@@ -217,7 +222,11 @@ export class Tracker {
       case ServerBoundAccelPacket.type: {
         const accel = packet as ServerBoundAccelPacket;
 
-        this.log(`Acceleration: ${accel.acceleration.join(', ')}`);
+        if (Array.isArray(accel.acceleration)) {
+          this.log(`Acceleration: ${accel.acceleration.join(', ')}`);
+        } else {
+          this.log(`Acceleration: ${accel.acceleration.x}, ${accel.acceleration.y}, ${accel.acceleration.z}`);
+        }
 
         break;
       }
@@ -343,9 +352,9 @@ export class Tracker {
           this.log(raw.toString());
         }
 
-        this.rawRotation.update(raw.rotation);
-        this.rawAcceleration.update(raw.acceleration);
-        this.rawMagnetometer.update(raw.magnetometer);
+        this.rawRotation.update(toVector(raw.rotation));
+        this.rawAcceleration.update(toVector(raw.acceleration));
+        this.rawMagnetometer.update(toVector(raw.magnetometer));
 
         if (shouldDumpRawIMUDataProcessed()) {
           this.log(`Raw | ROT | ${this.rawRotation.toString()}`);
@@ -357,11 +366,11 @@ export class Tracker {
           const csv =
             [
               Date.now(),
-              ...raw.rotation,
+              ...toVector(raw.rotation),
               raw.rotationAccuracy,
-              ...raw.acceleration,
+              ...toVector(raw.acceleration),
               raw.accelerationAccuracy,
-              ...raw.magnetometer,
+              ...toVector(raw.magnetometer),
               raw.magnetometerAccuracy
             ].join(',') + '\n';
           this.rawIMUDataRawStream.write(csv);
@@ -377,14 +386,14 @@ export class Tracker {
           this.log(fused.toString());
         }
 
-        this.fusedRotation.update(fused.quaternion);
+        this.fusedRotation.update(toQuaternion(fused.quaternion));
 
         if (shouldDumpFusedDataProcessed()) {
           this.log(`Fused | ${this.fusedRotation.toString()}`);
         }
 
         if (this.fusedIMUDataRawStream !== null) {
-          const csv = [Date.now(), ...fused.quaternion].join(',') + '\n';
+          const csv = [Date.now(), ...toQuaternion(fused.quaternion)].join(',') + '\n';
           this.fusedIMUDataRawStream.write(csv);
         }
 
@@ -398,14 +407,14 @@ export class Tracker {
           this.log(correction.toString());
         }
 
-        this.correctedRotation.update(correction.quaternion);
+        this.correctedRotation.update(toQuaternion(correction.quaternion));
 
         if (shouldDumpCorrectionDataProcessed()) {
           this.log(`Correction | ${this.correctedRotation.toString()}`);
         }
 
         if (this.correctionDataRawStream !== null) {
-          const csv = [Date.now(), ...correction.quaternion].join(',') + '\n';
+          const csv = [Date.now(), ...toQuaternion(correction.quaternion)].join(',') + '\n';
           this.correctionDataRawStream.write(csv);
         }
 

--- a/packages/firmware-protocol-debugger-utils/src/Tracker.ts
+++ b/packages/firmware-protocol-debugger-utils/src/Tracker.ts
@@ -178,11 +178,7 @@ export class Tracker {
       case ServerBoundGyroPacket.type: {
         const rot = packet as ServerBoundGyroPacket;
 
-        if (Array.isArray(rot.rotation)) {
-          this.log(`Gyroscope: ${rot.rotation.join(', ')}`);
-        } else {
-          this.log(`Gyroscope: ${rot.rotation.x}, ${rot.rotation.y}, ${rot.rotation.z}`);
-        }
+        this.log(`Gyroscope: ${toVector(rot.rotation).join(', ')}`);
 
         break;
       }
@@ -222,11 +218,7 @@ export class Tracker {
       case ServerBoundAccelPacket.type: {
         const accel = packet as ServerBoundAccelPacket;
 
-        if (Array.isArray(accel.acceleration)) {
-          this.log(`Acceleration: ${accel.acceleration.join(', ')}`);
-        } else {
-          this.log(`Acceleration: ${accel.acceleration.x}, ${accel.acceleration.y}, ${accel.acceleration.z}`);
-        }
+        this.log(`Acceleration: ${toVector(accel.acceleration).join(', ')}`);
 
         break;
       }

--- a/packages/firmware-protocol-debugger-utils/src/VectorAggretator.ts
+++ b/packages/firmware-protocol-debugger-utils/src/VectorAggretator.ts
@@ -1,4 +1,4 @@
-import { Vector, toVector } from "@slimevr/common";
+import { Vector } from "@slimevr/common";
 
 export class VectorAggregator<T extends number[] | Vector> {
   private readonly samples: number[];

--- a/packages/firmware-protocol-debugger-utils/src/VectorAggretator.ts
+++ b/packages/firmware-protocol-debugger-utils/src/VectorAggretator.ts
@@ -1,4 +1,6 @@
-export class VectorAggregator<T extends number[]> {
+import { Vector, toVector } from "@slimevr/common";
+
+export class VectorAggregator<T extends number[] | Vector> {
   private readonly samples: number[];
   private readonly averages: number[];
   private readonly deviances: number[];
@@ -19,12 +21,13 @@ export class VectorAggregator<T extends number[]> {
   }
 
   update(raw: T) {
-    if (raw.length !== this.components) {
-      throw new Error(`Expected ${this.components} components, got ${raw.length}`);
+    const length = Array.isArray(raw) ? raw.length : this.components;
+    if (length !== this.components) {
+      throw new Error(`Expected ${this.components} components, got ${raw}`);
     }
 
-    for (let component = 0; component < raw.length; component++) {
-      const value = raw[component];
+    for (let component = 0; component < length; component++) {
+      const value = Array.isArray(raw) ? raw[component] : 0;
 
       const previousSamples = this.samples[component];
       const previousAverage = this.averages[component];

--- a/packages/firmware-protocol-debugger-utils/src/utils.ts
+++ b/packages/firmware-protocol-debugger-utils/src/utils.ts
@@ -1,4 +1,4 @@
-import { Quaternion } from '@slimevr/common';
+import { Quaternion, toQuaternion } from '@slimevr/common';
 import { networkInterfaces } from 'os';
 
 export const getBroadcastAddresses = (): [string[], string[]] => {
@@ -32,9 +32,9 @@ export const getBroadcastAddresses = (): [string[], string[]] => {
 
 export const quaternionIsEqualWithEpsilon = (a: Quaternion, b: Quaternion) => {
   return (
-    Math.abs(a[0] - b[0]) < 0.0001 &&
-    Math.abs(a[1] - b[1]) < 0.0001 &&
-    Math.abs(a[2] - b[2]) < 0.0001 &&
-    Math.abs(a[3] - b[3]) < 0.0001
+    Math.abs(toQuaternion(a)[0] - toQuaternion(b)[0]) < 0.0001 &&
+    Math.abs(toQuaternion(a)[1] - toQuaternion(b)[1]) < 0.0001 &&
+    Math.abs(toQuaternion(a)[2] - toQuaternion(b)[2]) < 0.0001 &&
+    Math.abs(toQuaternion(a)[3] - toQuaternion(b)[3]) < 0.0001
   );
 };

--- a/packages/firmware-protocol-debugger-utils/src/utils.ts
+++ b/packages/firmware-protocol-debugger-utils/src/utils.ts
@@ -31,10 +31,13 @@ export const getBroadcastAddresses = (): [string[], string[]] => {
 };
 
 export const quaternionIsEqualWithEpsilon = (a: Quaternion, b: Quaternion) => {
+  const aQuaternion = toQuaternion(a);
+  const bQuaternion = toQuaternion(b);
+
   return (
-    Math.abs(toQuaternion(a)[0] - toQuaternion(b)[0]) < 0.0001 &&
-    Math.abs(toQuaternion(a)[1] - toQuaternion(b)[1]) < 0.0001 &&
-    Math.abs(toQuaternion(a)[2] - toQuaternion(b)[2]) < 0.0001 &&
-    Math.abs(toQuaternion(a)[3] - toQuaternion(b)[3]) < 0.0001
+    Math.abs(aQuaternion[0] - bQuaternion[0]) < 0.0001 &&
+    Math.abs(aQuaternion[1] - bQuaternion[1]) < 0.0001 &&
+    Math.abs(aQuaternion[2] - bQuaternion[2]) < 0.0001 &&
+    Math.abs(aQuaternion[3] - bQuaternion[3]) < 0.0001
   );
 };

--- a/packages/firmware-protocol/src/packets/ServerBoundAccelPacket.ts
+++ b/packages/firmware-protocol/src/packets/ServerBoundAccelPacket.ts
@@ -27,9 +27,11 @@ export class ServerBoundAccelPacket extends Packet {
     data.writeInt32BE(ServerBoundAccelPacket.type, 0);
     data.writeBigInt64BE(number, 4);
 
-    data.writeFloatBE(toVector(acceleration)[0], 12);
-    data.writeFloatBE(toVector(acceleration)[1], 16);
-    data.writeFloatBE(toVector(acceleration)[2], 20);
+    const accelerationVector = toVector(acceleration);
+
+    data.writeFloatBE(accelerationVector[0], 12);
+    data.writeFloatBE(accelerationVector[1], 16);
+    data.writeFloatBE(accelerationVector[2], 20);
 
     if (sensorId !== null) {
       data.writeUInt8(sensorId, 24);

--- a/packages/firmware-protocol/src/packets/ServerBoundAccelPacket.ts
+++ b/packages/firmware-protocol/src/packets/ServerBoundAccelPacket.ts
@@ -1,4 +1,4 @@
-import { Vector } from '@slimevr/common';
+import { Vector, toVector } from '@slimevr/common';
 import { Packet } from './Packet';
 
 export class ServerBoundAccelPacket extends Packet {
@@ -27,9 +27,9 @@ export class ServerBoundAccelPacket extends Packet {
     data.writeInt32BE(ServerBoundAccelPacket.type, 0);
     data.writeBigInt64BE(number, 4);
 
-    data.writeFloatBE(acceleration[0], 12);
-    data.writeFloatBE(acceleration[1], 16);
-    data.writeFloatBE(acceleration[2], 20);
+    data.writeFloatBE(toVector(acceleration)[0], 12);
+    data.writeFloatBE(toVector(acceleration)[1], 16);
+    data.writeFloatBE(toVector(acceleration)[2], 20);
 
     if (sensorId !== null) {
       data.writeUInt8(sensorId, 24);

--- a/packages/firmware-protocol/src/packets/ServerBoundRotationDataPacket.ts
+++ b/packages/firmware-protocol/src/packets/ServerBoundRotationDataPacket.ts
@@ -33,10 +33,12 @@ export class ServerBoundRotationDataPacket extends PacketWithSensorId {
     buf.writeUintBE(0, 0, 1);
     buf.writeUintBE(RotationDataType.NORMAL, 1, 1);
 
-    buf.writeFloatBE(toQuaternion(packet.rotation)[0], 2);
-    buf.writeFloatBE(toQuaternion(packet.rotation)[1], 6);
-    buf.writeFloatBE(toQuaternion(packet.rotation)[2], 10);
-    buf.writeFloatBE(toQuaternion(packet.rotation)[3], 14);
+    const rotationQuaternion = toQuaternion(packet.rotation);
+
+    buf.writeFloatBE(rotationQuaternion[0], 2);
+    buf.writeFloatBE(rotationQuaternion[1], 6);
+    buf.writeFloatBE(rotationQuaternion[2], 10);
+    buf.writeFloatBE(rotationQuaternion[3], 14);
 
     // I'd rather not want to jump through the deserializer
     return new ServerBoundRotationDataPacket(packet.number, buf);
@@ -63,10 +65,12 @@ export class ServerBoundRotationDataPacket extends PacketWithSensorId {
     buf.writeUintBE(sensorId, 12, 1);
     buf.writeUintBE(dataType, 13, 1);
 
-    buf.writeFloatBE(toQuaternion(rotation)[0], 14);
-    buf.writeFloatBE(toQuaternion(rotation)[1], 18);
-    buf.writeFloatBE(toQuaternion(rotation)[2], 22);
-    buf.writeFloatBE(toQuaternion(rotation)[3], 26);
+    const rotationQuaternion = toQuaternion(rotation);
+
+    buf.writeFloatBE(rotationQuaternion[0], 14);
+    buf.writeFloatBE(rotationQuaternion[1], 18);
+    buf.writeFloatBE(rotationQuaternion[2], 22);
+    buf.writeFloatBE(rotationQuaternion[3], 26);
 
     buf.writeUintBE(accuracyInfo, 30, 1);
 

--- a/packages/firmware-protocol/src/packets/ServerBoundRotationDataPacket.ts
+++ b/packages/firmware-protocol/src/packets/ServerBoundRotationDataPacket.ts
@@ -63,17 +63,10 @@ export class ServerBoundRotationDataPacket extends PacketWithSensorId {
     buf.writeUintBE(sensorId, 12, 1);
     buf.writeUintBE(dataType, 13, 1);
 
-    if (Array.isArray(rotation)) {
-      buf.writeFloatBE(rotation[0], 14);
-      buf.writeFloatBE(rotation[1], 18);
-      buf.writeFloatBE(rotation[2], 22);
-      buf.writeFloatBE(rotation[3], 26);
-    } else {
-      buf.writeFloatBE(rotation.x, 14);
-      buf.writeFloatBE(rotation.y, 18);
-      buf.writeFloatBE(rotation.z, 22);
-      buf.writeFloatBE(rotation.w, 26);
-    }
+    buf.writeFloatBE(toQuaternion(rotation)[0], 14);
+    buf.writeFloatBE(toQuaternion(rotation)[1], 18);
+    buf.writeFloatBE(toQuaternion(rotation)[2], 22);
+    buf.writeFloatBE(toQuaternion(rotation)[3], 26);
 
     buf.writeUintBE(accuracyInfo, 30, 1);
 

--- a/packages/firmware-protocol/src/packets/ServerBoundRotationDataPacket.ts
+++ b/packages/firmware-protocol/src/packets/ServerBoundRotationDataPacket.ts
@@ -1,4 +1,4 @@
-import { Quaternion } from '@slimevr/common';
+import { Quaternion, toQuaternion } from '@slimevr/common';
 import { ServerBoundRotationPacket } from '.';
 import { PacketWithSensorId } from './Packet';
 
@@ -32,10 +32,11 @@ export class ServerBoundRotationDataPacket extends PacketWithSensorId {
     // owoTrack only has one IMU so it will always be sensor ID 0
     buf.writeUintBE(0, 0, 1);
     buf.writeUintBE(RotationDataType.NORMAL, 1, 1);
-    buf.writeFloatBE(packet.rotation[0], 2);
-    buf.writeFloatBE(packet.rotation[1], 6);
-    buf.writeFloatBE(packet.rotation[2], 10);
-    buf.writeFloatBE(packet.rotation[3], 14);
+
+    buf.writeFloatBE(toQuaternion(packet.rotation)[0], 2);
+    buf.writeFloatBE(toQuaternion(packet.rotation)[1], 6);
+    buf.writeFloatBE(toQuaternion(packet.rotation)[2], 10);
+    buf.writeFloatBE(toQuaternion(packet.rotation)[3], 14);
 
     // I'd rather not want to jump through the deserializer
     return new ServerBoundRotationDataPacket(packet.number, buf);
@@ -61,10 +62,18 @@ export class ServerBoundRotationDataPacket extends PacketWithSensorId {
 
     buf.writeUintBE(sensorId, 12, 1);
     buf.writeUintBE(dataType, 13, 1);
-    buf.writeFloatBE(rotation[0], 14);
-    buf.writeFloatBE(rotation[1], 18);
-    buf.writeFloatBE(rotation[2], 22);
-    buf.writeFloatBE(rotation[3], 26);
+
+    if (Array.isArray(rotation)) {
+      buf.writeFloatBE(rotation[0], 14);
+      buf.writeFloatBE(rotation[1], 18);
+      buf.writeFloatBE(rotation[2], 22);
+      buf.writeFloatBE(rotation[3], 26);
+    } else {
+      buf.writeFloatBE(rotation.x, 14);
+      buf.writeFloatBE(rotation.y, 18);
+      buf.writeFloatBE(rotation.z, 22);
+      buf.writeFloatBE(rotation.w, 26);
+    }
 
     buf.writeUintBE(accuracyInfo, 30, 1);
 


### PR DESCRIPTION
This PR allows the `Vector` and `Quaternion` types to accept objects.

Vector now accepts: `[number, number, number]` OR `{ x: number; y: number; z: number }`
Quaternion now accepts: `[number, number, number, number]` OR `{ x: number; y: number; z: number; w: number }`